### PR TITLE
Rebalance only at configurable intervals

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,19 @@ kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/
 ```bash
 kubectl create namespace observability
 kubectl create -f https://github.com/jaegertracing/jaeger-operator/releases/download/v1.40.0/jaeger-operator.yaml -n observability
+kubectl apply -f k8s/cluster/jaeger.yaml
+```
+
+**Forwarding the Jaeger Trace port on Kuberenetes master node**
+
+```bash
+kubectl port-forward -n slops svc/jaeger-trace-query 16686:16686
+```
+
+**Forwarding the Jaeger Trace port over SSH**
+
+```bash
+ssh -L 16686:localhost:16686 node0
 ```
 
 ## Kafka Commands

--- a/SLOPSProducer/cmd/app.go
+++ b/SLOPSProducer/cmd/app.go
@@ -3,6 +3,7 @@ package main
 import (
 	"log"
 	"sync"
+	"time"
 
 	"github.com/MSrvComm/SLOPSProducer/internal"
 )
@@ -15,9 +16,23 @@ type Application struct {
 	ch               chan string      // Receive incoming keys through this channel.
 	conf             internal.Config  // Hold the configuration data.
 	keyMap           *internal.KeyMap // Mapping of hot keys.
+	backupKeyMap     *internal.KeyMap // Add new mappings to the backup and swap every 30 seconds.
 	messageSets      *MessageSetMap   // Map Message Sets
 	partitionWeights []float64        // Weights of each partition.
 	logger           *log.Logger      // System level logger.
 	// randomPartitioner *internal.RandomPartitioner
-	producer Producer // Kafka producer.
+	producer     Producer // Kafka producer.
+	mapSwapTimer time.Ticker
+}
+
+// Swap the map every interval set in the ticker.
+func (app *Application) SwapMaps() {
+	for range app.mapSwapTimer.C { // Swap the structs.
+		log.Println("Swapping the maps")
+		newMap := make(map[string]internal.KeyRecord)
+		for k, v := range app.backupKeyMap.KV {
+			newMap[k] = v
+		}
+		app.keyMap.KV = newMap
+	}
 }

--- a/SLOPSProducer/cmd/message.go
+++ b/SLOPSProducer/cmd/message.go
@@ -35,7 +35,7 @@ func (app *Application) NewMessage(c *gin.Context) {
 			app.ch <- input.Key // Send the key to the lossy counter.
 		}
 		var partition int32
-		if rec, err := app.keyMap.GetKey(input.Key); err != nil {
+		if rec, err := app.keyMap.GetKey(input.Key); err != nil { // Use KeyMap to decide partition.
 			// partition = app.randomPartitioner.Partition(app.conf.Partitions)
 			partition, err = hash(input.Key, app.conf.Partitions)
 			if err != nil {
@@ -45,7 +45,7 @@ func (app *Application) NewMessage(c *gin.Context) {
 			partition = rec.Partition
 			// Message Set header will be added by `Producer` when message is sent.
 			if rec.Delete {
-				app.keyMap.Del(rec.Key)
+				app.backupKeyMap.Del(rec.Key) // Delete in the backup key map only.
 			}
 		}
 		go app.Produce(input.Key, input.Body, partition)

--- a/SLOPSProducer/internal/config.go
+++ b/SLOPSProducer/internal/config.go
@@ -14,6 +14,7 @@ type Config struct {
 	Partitions         int32   `yaml:"partitions"`
 	GRPCPort           int     `yaml:"grpc_port"`
 	HTTPPort           int     `yaml:"http_port"`
+	SwapInterval       int     `yaml:"swap_interval"`
 }
 
 func (c *Config) Parse(data []byte) error {

--- a/k8s/producer/configmap.yaml
+++ b/k8s/producer/configmap.yaml
@@ -16,3 +16,4 @@ data:
     partitions: 10
     grpc_port: 4000
     http_port: 2048
+    swap_interval: 10

--- a/k8s/producer/deployment.yaml
+++ b/k8s/producer/deployment.yaml
@@ -50,11 +50,14 @@ spec:
         - name: KAFKA_BOOTSTRAP
           value: "ordergo-kafka-bootstrap:9092"
         - name: VANILLA
-          value: "false"
+          # value: "true" # original Kafka
+          value: "false" # SMALOPS
         - name: P2C
-          value: "true"
+          # value: "false"  # original Kafka
+          value: "true" # SMALOPS
         - name: LOSSY
-          value: "true"
+          # value: "false" # original Kafka
+          value: "true" # SMALOPS
         - name: TRACER_NAME
           value: "producer"
         - name: TRACER_COLLECTOR


### PR DESCRIPTION
When hot keys are detected, rather than immediately rebalancing them we now calculate `hot key -> partition` mappings and store it in a backup map. Every c seconds, configurable, we swap the backup and main maps. The application fetches its current mapping from the main map.